### PR TITLE
Allow users to set the output directory

### DIFF
--- a/src/main/groovy/ws/antonov/gradle/plugins/protobuf/ProtobufConvention.groovy
+++ b/src/main/groovy/ws/antonov/gradle/plugins/protobuf/ProtobufConvention.groovy
@@ -12,4 +12,9 @@ class ProtobufConvention {
      * Directory to extract proto files into
      */
     def String extractedProtosDir
+		
+		/**
+		 *	Directory to save java files to
+		 */
+		def String generatedFileDir 
 }

--- a/src/main/groovy/ws/antonov/gradle/plugins/protobuf/ProtobufPlugin.groovy
+++ b/src/main/groovy/ws/antonov/gradle/plugins/protobuf/ProtobufPlugin.groovy
@@ -92,9 +92,10 @@ class ProtobufPlugin implements Plugin<Project> {
     }
 
     private getGeneratedSourceDir(Project project, SourceSet sourceSet) {
+				if(project.generatedFileDir != null)
+					return project.generatedFileDir
+				
         def generatedSourceDir = 'generated-sources'
-        //if (sourceSet.name != SourceSet.MAIN_SOURCE_SET_NAME)
-        //    generatedSourceDir = "${sourceSet.name}-generated-sources"
         return "${project.buildDir}/${generatedSourceDir}/${sourceSet.name}"
     }
 


### PR DESCRIPTION
I wrote a plugin that moved the output of the source. My workflow needs to move the output java files into the src/main/java so that an IDE can see them.
