### PR TITLE
Make the appending of ${sourceSet.name} to ${generatedFileDir} optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ protocPath = '/usr/local/bin/protoc'
 // Optional - defaults to value below
 extractedProtosDir = "${project.buildDir.path}/extracted-protos"
 // Optional - defaults to "${project.buildDir}/generated-sources/${sourceSet.name}"
-generatedFileDir = "${projectDir}/src" // This directory will get the current sourceSet.name appended to it. i.e. src/main or src/test
+generatedFileDir = "${projectDir}/src"
+// Optional - defaults to true (append the current ${sourceSet.name} to ${generatedFileDir})
+appendSourceSetName = false
 
 dependencies {
     // If you have your protos archived in a tar file, you can specify that as a dependency

--- a/src/main/groovy/ws/antonov/gradle/plugins/protobuf/ProtobufConvention.groovy
+++ b/src/main/groovy/ws/antonov/gradle/plugins/protobuf/ProtobufConvention.groovy
@@ -13,6 +13,11 @@ class ProtobufConvention {
      */
     def String extractedProtosDir
 		
+    /**
+     * Whether ${sourceSet.name} should be appended to ${generatedFileDir}
+     */
+    def boolean appendSourceSetName
+
 		/**
 		 *	Directory to save java files to
 		 */

--- a/src/main/groovy/ws/antonov/gradle/plugins/protobuf/ProtobufPlugin.groovy
+++ b/src/main/groovy/ws/antonov/gradle/plugins/protobuf/ProtobufPlugin.groovy
@@ -96,7 +96,10 @@ class ProtobufPlugin implements Plugin<Project> {
         if(project.generatedFileDir != null)
 	    generatedSourceDir = project.generatedFileDir
 				
-        return "${generatedSourceDir}/${sourceSet.name}"
+        if (project.appendSourceSetName == null || project.appendSourceSetName == true)
+            return "${generatedSourceDir}/${sourceSet.name}"
+        else
+            return "${generatedSourceDir}"
     }
 
 }


### PR DESCRIPTION
In my case I have the directory layout:

```
src/main/java
src/test/java
```

And I actually want my generated sources to end up inside src/main/java, alongside my normal sources. Currently it's impossible to turn off the appending of ${sourceSet.name} to ${generatedFileDir}, so with

```
generatedFileDir = "src/main/java"
```

my sources would end up in "src/main/java/main" (!).

This pull request adds the appendSourceSetName boolean property for controlling the appending of the current ${sourceSet.name} to ${generatedFileDir}. The default value is true (it will be appended).
