### PR TITLE
Update version check to allow for gradle 2.0 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'git'
 apply plugin: 'signing'
 
 group = 'ws.antonov.gradle.plugins'
-version = '0.9.1'
+version = '0.9.2'
 
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 

--- a/src/main/groovy/ws/antonov/gradle/plugins/protobuf/ProtobufPlugin.groovy
+++ b/src/main/groovy/ws/antonov/gradle/plugins/protobuf/ProtobufPlugin.groovy
@@ -16,7 +16,7 @@ import org.gradle.util.CollectionUtils
 class ProtobufPlugin implements Plugin<Project> {
     void apply(final Project project) {
         def gv = project.gradle.gradleVersion =~ "(\\d*)\\.(\\d*).*"
-        if (!gv || !gv.matches() || gv.group(1) < "1" || gv.group(2) < "12") {
+        if (!gv || !gv.matches() || gv.group(1) < "1" || (gv.group(1) == "1" && gv.group(2) < "12")) {
             //throw new UnsupportedVersionException
             println("You are using Gradle ${project.gradle.gradleVersion}: This version of the protobuf plugin requires minimum Gradle version 1.12")
         }

--- a/testProject/build.gradle
+++ b/testProject/build.gradle
@@ -9,7 +9,7 @@ Running script ${relativePath(buildFile)}
 
 buildscript {
     dependencies {
-        classpath files("../build/libs/gradle-plugin-protobuf-0.9.jar")
+        classpath files("../build/libs/gradle-plugin-protobuf-0.9.2.jar")
     }
 }
 


### PR DESCRIPTION
Seems to work fine in gradle 2.0, was just blocked by the version check asserting that 0 < 12.
